### PR TITLE
allow setting body in OHTTP requests

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,3 @@
 FROM rust:1.84.1
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -yq curl build-essential jq openssl libssl-dev
+RUN apt-get update && apt-get install -yq curl build-essential jq openssl libssl-dev libpython3-dev python3.11-venv python3-pip

--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ Build the pyohttp package as follows.
 ```shell
 ./scripts/build-pyohttp.sh
 ```
-
-The [sample python script](samples/ohttp-client-cli.py) shows how to make an attested OHTTP inference request to a Confidential Whisper endpoint using this package. 
+Install the package from ```target/wheels``` using pip. The [sample python script](samples/ohttp-client-cli.py) shows how use this package and make an attested OHTTP inference request to a confidential whisper endpoint. 
 
 ## Docker
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,33 @@ Azure AI confidential inferencing on Linux.
 2. An AzureML endpoint with a confidential whisper model. 
 3. Docker 
 
-## Using pre-built image
+## Clients
 
-You can use pre-built attested OHTTP container images to send an inferencing request. 
+We support the following client profiles. 
+
+- [Python package](#python-package)
+- [Docker CLI](#docker)
+- [Rust CLI](#rust)
+
+Rust and python packages can be built using this repo. We support development and build using GitHub Codespaces and devcontainers. The repository includes a devcontainer configuration that installs all dependencies. 
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/microsoft/attested-ohttp-client)
+
+## Python package
+
+Build the pyohttp package as follows. 
+
+```shell
+./scripts/build-pyohttp.sh
+```
+
+The [sample python script](samples/ohttp-client-cli.py) shows how to make an attested OHTTP inference request to a Confidential Whisper endpoint using this package. 
+
+## Docker
+
+### Using pre-built image
+
+You can use pre-built attested OHTTP container images to send inferencing requests and print completions. 
 
 Set the inferencing endpoint and access key as follows.
 ```
@@ -40,7 +64,7 @@ Run inferencing using your own audio file by mounting the file into the containe
 The maximum audio file size supported is 25MB.
 ```
 export KMS_URL=https://accconfinferenceprod.confidential-ledger.azure.com
-export INPUT_PATH=<path_to_your_input_audio_file_exclusing_name>
+export INPUT_PATH=<path_to_your_input_audio_file_excluding_name>
 export INPUT_FILE=<name_of_your_audio_file>
 export MOUNTED_PATH=/test
 docker run -e KMS_URL=${KMS_URL} --volume ${INPUT_PATH}:${MOUNTED_PATH} \
@@ -48,20 +72,15 @@ docker run -e KMS_URL=${KMS_URL} --volume ${INPUT_PATH}:${MOUNTED_PATH} \
   ${TARGET_URI} -F "file=@${MOUNTED_PATH}/${INPUT_FILE}" -O "api-key: ${API_KEY}" -F "response_format=json"
 ```
 
-## Building your own container image
-
-### Development Environment
-
-The repo supports development using GitHub Codespaces and devcontainers. The repository includes a devcontainer configuration that installs all dependencies. 
-
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/microsoft/attested-ohttp-client)
+### Build your own container image
 
 You can build the client container using docker.
 ```
 docker build -f docker/Dockerfile -t attested-ohttp-client .
 ```
 
-Alternatively, you can setup your own environment by installing dependencies.
+## Rust 
+Setup environment by installing dependencies.
 ```
 sudo apt update
 sudo apt install -y curl build-essential jq libssl-dev
@@ -70,5 +89,12 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
 Build the client using cargo. 
 ```
-cargo build --bin ohttp-client
+cargo build --bin ohttp-client-cli
+```
+
+Run the CLI as follows.
+```
+curl -s -k ${KMS_URL}/node/network | jq -r .service_certificate > /tmp/service_cert.pem
+cargo run --bin=ohttp-client-cli -- ${TARGET_URI} -F "file=examples/audio.mp3" \
+	-O "api-key: ${API_KEY}" --kms-url=${KMS_URL} --kms-cert=/tmp/service_cert.pem
 ```

--- a/ohttp-client-cli/src/main.rs
+++ b/ohttp-client-cli/src/main.rs
@@ -44,15 +44,18 @@ struct Args {
 
     /// List of headers in the inner request
     #[arg(long, short = 'H')]
-    headers: Vec<String>,
+    headers: Option<Vec<String>>,
+
+    #[arg(long, short = 'd', default_value = "")]
+    data: Option<String>,
 
     /// List of fields in the inner request
     #[arg(long, short = 'F')]
-    form_fields: Vec<String>,
+    form_fields: Option<Vec<String>>,
 
     /// List of headers in the outer request
     #[arg(long, short = 'O')]
-    outer_headers: Vec<String>,
+    outer_headers: Option<Vec<String>>,
 }
 
 #[tokio::main]
@@ -80,6 +83,7 @@ async fn main() -> Res<()> {
             &args.url,
             &args.target_path,
             &args.headers,
+            &args.data,
             &args.form_fields,
             &args.outer_headers,
         )

--- a/pyohttp/src/lib.rs
+++ b/pyohttp/src/lib.rs
@@ -70,16 +70,17 @@ impl OhttpClient {
     pub fn post_raw<'py>(
         &self,
         url: String,
-        outer_headers: HashMap<String, String>,
         http_request: Vec<u8>,
+        outer_headers: Option<HashMap<String, String>>,
         py: Python<'py>,
     ) -> PyResult<&'py PyAny> {
         let kms_url = self.kms_url.clone();
         let kms_cert = self.kms_cert.clone();
-        let outer_headers = outer_headers
-            .iter()
-            .map(|(key, value)| format!("{}: {}", key, value))
-            .collect();
+        let outer_headers = outer_headers.map(|h| {
+            h.iter()
+                .map(|(key, value)| format!("{}: {}", key, value))
+                .collect::<Vec<String>>()
+        });
 
         pyo3_asyncio::tokio::future_into_py(py, async move {
             let client = OhttpClientBuilder::new()
@@ -107,25 +108,29 @@ impl OhttpClient {
     pub fn post<'py>(
         &self,
         url: String,
-        headers: HashMap<String, String>,
-        form_fields: HashMap<String, String>,
-        outer_headers: HashMap<String, String>,
+        headers: Option<HashMap<String, String>>,
+        data: Option<String>,
+        form_fields: Option<HashMap<String, String>>,
+        outer_headers: Option<HashMap<String, String>>,
         py: Python<'py>,
     ) -> PyResult<&'py PyAny> {
         let kms_url = self.kms_url.clone();
         let kms_cert = self.kms_cert.clone();
-        let headers = headers
-            .iter()
-            .map(|(key, value)| format!("{}: {}", key, value))
-            .collect();
-        let form_fields = form_fields
-            .iter()
-            .map(|(key, value)| format!("{}={}", key, value))
-            .collect();
-        let outer_headers = outer_headers
-            .iter()
-            .map(|(key, value)| format!("{}: {}", key, value))
-            .collect();
+        let headers = headers.map(|h| {
+            h.iter()
+                .map(|(key, value)| format!("{}: {}", key, value))
+                .collect::<Vec<String>>()
+        });
+        let form_fields = form_fields.map(|f| {
+            f.iter()
+                .map(|(key, value)| format!("{}={}", key, value))
+                .collect::<Vec<String>>()
+        });
+        let outer_headers = outer_headers.map(|o| {
+            o.iter()
+                .map(|(key, value)| format!("{}: {}", key, value))
+                .collect::<Vec<String>>()
+        });
 
         pyo3_asyncio::tokio::future_into_py(py, async move {
             let client = OhttpClientBuilder::new()
@@ -138,7 +143,7 @@ impl OhttpClient {
                 })?;
 
             let response = client
-                .post(&url, "/", &headers, &form_fields, &outer_headers)
+                .post(&url, "/", &headers, &data, &form_fields, &outer_headers)
                 .await
                 .map_err(|e: Box<dyn std::error::Error>| {
                     PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/samples/ohttp-whisper-cli.py
+++ b/samples/ohttp-whisper-cli.py
@@ -1,0 +1,46 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import pyohttp
+import requests
+import asyncio
+import json
+import argparse
+
+def download_kms_certificate(kms_url, output_file):
+  response = requests.get(kms_url + "/node/network", verify=False)
+  if response.status_code == 200:
+    service_certificate = json.loads(response.text).get("service_certificate", "")
+    if service_certificate:
+        with open(output_file, "w") as file:
+            file.write(service_certificate)
+    else:
+        assert False
+  else:
+    assert False
+
+async def infer(target_uri, api_key, audio_file, kms_url):
+  ohttp_client = pyohttp.OhttpClient(kms_url, kms_cert_path)
+  form_fields = {"file": "@" + audio_file, "response_format": "json" }
+  outer_headers = { "api-key": api_key }
+  response = await ohttp_client.post(target_uri, form_fields=form_fields, outer_headers=outer_headers)
+  print(response.status())
+  if response.status() == 200:
+    while True:
+      result = await response.chunk()
+      if result is None:
+        break
+      print(bytearray(result).decode('utf-8'))
+  return
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Process some strings.")
+    parser.add_argument("--target-uri", type=str, help="The target URI")
+    parser.add_argument("--api-key", type=str, help="The API key")
+    parser.add_argument("--audio-file", type=str, help="The audio file path")
+    parser.add_argument("--kms-url", type=str, help="The KMS URL")
+
+    args = parser.parse_args()
+    kms_cert_path = "/tmp/service_cert.pem"
+    download_kms_certificate(args.kms_url, kms_cert_path)
+    asyncio.run(infer(args.target_uri, args.api_key, args.audio_file, args.kms_url))

--- a/test/tests_ohttp.py
+++ b/test/tests_ohttp.py
@@ -32,8 +32,7 @@ def ohttp_client(request):
 async def test_basic(ohttp_client, target_uri, api_key, audio_file):
   form_fields = {"file": "@" + audio_file, "response_format": "json" }
   outer_headers = { "api-key": api_key }
-  headers = {}
-  response = await ohttp_client.post(target_uri, headers, form_fields, outer_headers)
+  response = await ohttp_client.post(target_uri, form_fields=form_fields, outer_headers=outer_headers)
   status = response.status()
   for key, value in response.headers().items():
     print(f"{key}: {value}")
@@ -44,8 +43,7 @@ async def test_basic(ohttp_client, target_uri, api_key, audio_file):
 async def test_attestation_token(ohttp_client, target_uri, api_key, audio_file):
   form_fields = {"file": "@" + audio_file, "response_format": "json" }
   outer_headers = { "api-key": api_key, "x-attestation-token": "true" }
-  headers = {}
-  response = await ohttp_client.post(target_uri, headers, form_fields, outer_headers)
+  response = await ohttp_client.post(target_uri, form_fields=form_fields, outer_headers=outer_headers)
   status = response.status()
   for key, value in response.headers().items():
     print(f"{key}: {value}")
@@ -57,8 +55,7 @@ async def test_attestation_token(ohttp_client, target_uri, api_key, audio_file):
 async def test_invalid_api_key(ohttp_client, target_uri, audio_file):
   form_fields = {"file": "@" + audio_file, "response_format": "json" }
   outer_headers = { "api-key": "invalid_key" }
-  headers = {}
-  response = await ohttp_client.post(target_uri, headers, form_fields, outer_headers)
+  response = await ohttp_client.post(target_uri, form_fields=form_fields, outer_headers=outer_headers)
   status = response.status()
   for key, value in response.headers().items():
     print(f"{key}: {value}")


### PR DESCRIPTION
This PR extends the client to support setting body in the OHTTP requests. In the CLI, this can be done using the -d argument. The PR also makes the following related changes.

- Makes parameters to the post API optional
- Add python sample application which shows use of python bindings
- Improved README on how to use different kinds of clients
- Fix devcontainer dependencies

Passes all Rust and python tests. 